### PR TITLE
[docker] Make system package versions less specific

### DIFF
--- a/carla/Dockerfile
+++ b/carla/Dockerfile
@@ -8,21 +8,21 @@ ARG MAPS_ARCHIVE_URL=https://carla-releases.s3.us-east-005.backblazeb2.com/Linux
 USER root
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    wget=1.20.3-1ubuntu2.1 \
-    curl=7.68.0-1ubuntu2.25 \
-    ca-certificates=20240203~20.04.1 \
-    git=1:2.25.1-1ubuntu3.14 \
-    build-essential=12.8ubuntu1.1 \
-    libssl-dev=1.1.1f-1ubuntu2.24 \
-    zlib1g-dev=1:1.2.11.dfsg-2ubuntu1.5 \
-    libbz2-dev=1.0.8-2 \
-    libreadline-dev=8.0-4 \
-    libsqlite3-dev=3.31.1-4ubuntu0.7 \
-    libncurses5-dev=6.2-0ubuntu2.1 \
-    libncursesw5-dev=6.2-0ubuntu2.1 \
-    xz-utils=5.2.4-1ubuntu1.1 \
-    fontconfig=2.13.1-2ubuntu3 \
-    ttf-ubuntu-font-family=1:0.83-4ubuntu1 && \
+    wget=1.20.* \
+    curl=7.68.* \
+    ca-certificates=20240203~20.04.* \
+    git=1:2.25.* \
+    build-essential=12.8* \
+    libssl-dev=1.1.* \
+    zlib1g-dev=1:1.2.* \
+    libbz2-dev=1.0.* \
+    libreadline-dev=8.0-* \
+    libsqlite3-dev=3.31.* \
+    libncurses5-dev=6.2-* \
+    libncursesw5-dev=6.2-* \
+    xz-utils=5.2.* \
+    fontconfig=2.13.* \
+    ttf-ubuntu-font-family=1:0.83-* && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 

--- a/sumo/Dockerfile
+++ b/sumo/Dockerfile
@@ -9,18 +9,18 @@ ARG GID=1000
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential=12.9 \
-    cmake=3.25.1-1 \
-    git=1:2.39.5-0+deb12u3 \
-    bash=5.2.15-2+b13 \
-    ca-certificates=20230311+deb12u1 \
-    curl=7.88.1-10+deb12u14 \
-    libssl-dev=3.0.20-1~deb12u1 \
-    libbz2-dev=1.0.8-5+b1 \
-    zlib1g-dev=1:1.2.13.dfsg-1 \
-    libxrender1=1:0.9.10-1.1 \
-    libsm6=2:1.2.3-1 \
-    libxext6=2:1.3.4-1+b1 \
-    ffmpeg=7:5.1.8-0+deb12u1 \
+    cmake=3.25.* \
+    git=1:2.39.* \
+    bash=5.2.* \
+    ca-certificates=20230311* \
+    curl=7.88.* \
+    libssl-dev=3.0.* \
+    libbz2-dev=1.0.* \
+    zlib1g-dev=1:1.2.* \
+    libxrender1=1:0.9.* \
+    libsm6=2:1.2.* \
+    libxext6=2:1.3.* \
+    ffmpeg=7:5.1.* \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Why is it needed? -->
Relax package version pinning in container images

## Related issue

<!-- Use Closes #123 only if this PR fully resolves the issue. -->
https://github.com/CAVISE/OpenCDA/issues/176

## Changes

- Relax package version pinning in container images

## Validation

<!-- How was this tested or validated? -->

- [x] Simulation run
- [x] Manual verification
- [ ] Not applicable

## Checklist

- [x] Linked the related issue
- [x] Kept the PR focused and reviewable
- [x] Updated documentation if needed
- [ ] Added or updated validation steps if needed
