### PR TITLE
[docker-compose, run.sh] Add multistage build support for OpenCDA in run.sh and docker-compose.yml

### DIFF
--- a/dc-configs/docker-compose.yml
+++ b/dc-configs/docker-compose.yml
@@ -51,9 +51,11 @@ services:
     build:
       context: ${CAVISE_ROOT}
       dockerfile: ${PATH_TO_OPENCDA}/Dockerfile
+      target: ${OPENCDA_BUILD_TARGET:-opencda}
       args:
         UID: 1000  # Example: use your actual UID from `echo $UID`
-    image: opencda:local
+        CUDA_ARCHITECTURES: "${CUDA_ARCHITECTURES:-86}"
+    image: opencda:${OPENCDA_IMAGE_TAG:-local}
     container_name: opencda
     command: ["sh", "-c", "sleep infinity"]
     networks:
@@ -69,7 +71,6 @@ services:
             - capabilities: [gpu]
               driver: nvidia
     volumes:
-      - ${CAVISE_ROOT}/cavise/messages:/home/opencda/cavise/messages
       - ${PATH_TO_OPENCDA}:/home/opencda/cavise/opencda
       - ${PATH_TO_SUMO}/assets:/home/opencda/cavise/opencda/opencda/sumo-assets
       - /usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d

--- a/run.sh
+++ b/run.sh
@@ -32,36 +32,112 @@ run_compose() {
     fi
 }
 
+resolve_opencda_target() {
+    local selected_target=""
+    local service
+    local -a resolved_services=()
+    local -A seen_services=()
+
+    for service in $services; do
+        case "$service" in
+          opencda|opencda-minimal|opencda-protobuf|opencda-cuda)
+            if [ -n "$selected_target" ] && [ "$selected_target" != "$service" ]; then
+                echo "Error: multiple OpenCDA build targets requested: $selected_target and $service" >&2
+                exit 1
+            fi
+            selected_target="$service"
+            service="opencda"
+            ;;
+        esac
+
+        if [ -z "${seen_services[$service]+set}" ]; then
+            resolved_services+=("$service")
+            seen_services["$service"]=1
+        fi
+    done
+
+    OPENCDA_BUILD_TARGET="${selected_target:-opencda}"
+    case "$OPENCDA_BUILD_TARGET" in
+      opencda)
+        OPENCDA_IMAGE_TAG="local"
+        ;;
+      opencda-minimal)
+        OPENCDA_IMAGE_TAG="minimal"
+        ;;
+      opencda-protobuf)
+        OPENCDA_IMAGE_TAG="protobuf"
+        ;;
+      opencda-cuda)
+        OPENCDA_IMAGE_TAG="cuda"
+        ;;
+    esac
+
+    export OPENCDA_BUILD_TARGET
+    export OPENCDA_IMAGE_TAG
+    services="${resolved_services[*]}"
+}
+
+resolve_opencda_target
+
+uses_opencda_service() {
+    [ -z "$services" ] || [[ " $services " == *" opencda "* ]]
+}
+
 case "$command" in
   build)
-    echo "Building container images..."
+    if uses_opencda_service; then
+        echo "Building container images (OpenCDA target: $OPENCDA_BUILD_TARGET)..."
+    else
+        echo "Building container images..."
+    fi
     run_compose build $services
     ;;
   up)
-    echo "Creating and starting containers..."
+    if uses_opencda_service; then
+        echo "Creating and starting containers (OpenCDA target: $OPENCDA_BUILD_TARGET)..."
+    else
+        echo "Creating and starting containers..."
+    fi
     run_compose "up -d" $services
     if echo "$services" | grep -qw "scenario-manager"; then
         xdg-open http://localhost 2>/dev/null || open http://localhost 2>/dev/null || start http://localhost
     fi
     ;;
   down)
-    echo "Stopping and removing containers..."
+    if uses_opencda_service; then
+        echo "Stopping and removing containers (OpenCDA target: $OPENCDA_BUILD_TARGET)..."
+    else
+        echo "Stopping and removing containers..."
+    fi
     run_compose down $services
     ;;
   start)
-    echo "Starting existing containers..."
+    if uses_opencda_service; then
+        echo "Starting existing containers (OpenCDA target: $OPENCDA_BUILD_TARGET)..."
+    else
+        echo "Starting existing containers..."
+    fi
     run_compose start $services
     ;;
   stop)
-    echo "Stopping running containers..."
+    if uses_opencda_service; then
+        echo "Stopping running containers (OpenCDA target: $OPENCDA_BUILD_TARGET)..."
+    else
+        echo "Stopping running containers..."
+    fi
     run_compose stop $services
     ;;
   restart)
-    echo "Restarting containers..."
+    if uses_opencda_service; then
+        echo "Restarting containers (OpenCDA target: $OPENCDA_BUILD_TARGET)..."
+    else
+        echo "Restarting containers..."
+    fi
     run_compose restart $services
     ;;
   *)
     echo "Usage: $0 {build|up|start|stop|down|restart} [services...]"
+    echo "OpenCDA targets: opencda, opencda-minimal, opencda-protobuf, opencda-cuda"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Adds support for selecting OpenCDA multi-stage Docker targets through the existing CAVISE `run.sh` interface.

Users can build and operate minimal, Protobuf-only, CUDA-only, or complete OpenCDA images without invoking `docker build` or Docker Compose directly.

Companion PR:
- CAVISE/OpenCDA#182

## Changes

- Added the `opencda-minimal`, `opencda-protobuf`, `opencda-cuda`, and complete `opencda` target aliases.
- Added target resolution for `build`, `up`, `start`, `stop`, `restart`, and `down`.
- Mapped each target to a separate image tag: `minimal`, `protobuf`, `cuda`, or `local`.
- Added validation that prevents multiple conflicting OpenCDA targets from being requested together.
- Passed the selected build target and configurable `CUDA_ARCHITECTURES` value to Docker Compose.
- Removed the obsolete CAVISE messages bind mount because generated Protobuf modules are now managed inside the OpenCDA workspace.
- Updated the `run.sh` usage output with the available OpenCDA targets.

## Validation

- [x] Built the `opencda-minimal` image target.
- [x] Built the `opencda-protobuf` image target.
- [x] Built the `opencda-cuda` image target.
- [x] Started the Protobuf target through `./run.sh up opencda-protobuf`.
- [x] Verified separate image tags for the selected OpenCDA targets.
- [x] CodeQL, lint, format, type checking, unused-code, and pre-commit checks pass.
- [x] Manual verification

## Checklist

- [x] Kept the PR focused and reviewable
- [x] Updated documentation if needed
- [x] Added or updated validation steps if needed